### PR TITLE
Entity problem with external file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ addopts =
 	--ignore=test_requirements.txt
 	--ignore=ci
 	--ignore=.eggs
-	--tb=auto
-	--showlocals
+	--tb=short
 
 [check-manifest]
 ignore = 

--- a/src/dbxincluder/xinclude.py
+++ b/src/dbxincluder/xinclude.py
@@ -289,7 +289,7 @@ def handle_xinclude(elem, base_url, xmlcatalog=None, file=None, xinclude_stack=N
 
     # Parse as XML
     try:
-        subtree = fromstring(content)
+        subtree = fromstring(content, base_url=url)
     except (XMLSyntaxError, UnicodeDecodeError) as exc:
         raise DBXIException(elem, "Could not parse {0!r}: {1}".format(url, str(exc)), file)
 

--- a/tests/cases/entity-decl.ent
+++ b/tests/cases/entity-decl.ent
@@ -1,0 +1,2 @@
+<!ENTITY bar "Found bar!">
+<!ENTITY foo "Found foo!">

--- a/tests/cases/entity.case.xml
+++ b/tests/cases/entity.case.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article [
+  <!ENTITY foo "Found foo!">
+]>
+<article version="5.0"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>Transclusions demo</title>
+  <para>&foo;</para>
+  <xi:include href="xinclude1.xml"/>
+</article>

--- a/tests/cases/entity.out.xml
+++ b/tests/cases/entity.out.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE article [
+<!ENTITY foo "Found foo!">
+]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="tests/cases/entity.case.xml">
+  <title>Transclusions demo</title>
+  <para>Found foo!</para>
+  <sect1 version="5.0" xml:id="sec.parent" xml:base="tests/cases/xinclude1.xml">
+    <sect2 xml:id="sec.first">
+        <para>First section!</para>
+    </sect2>
+    <sect2 xml:id="sec.ond">
+        <para>Second section!</para>
+    </sect2>
+</sect1>
+</article>

--- a/tests/cases/xinclude-with-entity.case.xml
+++ b/tests/cases/xinclude-with-entity.case.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<article version="5.0"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>Transclusions demo</title>
+  <xi:include href="xinclude2.xml"/>
+</article>

--- a/tests/cases/xinclude-with-entity.out.xml
+++ b/tests/cases/xinclude-with-entity.out.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="tests/cases/xinclude-with-entity.case.xml">
+  <title>Transclusions demo</title>
+  <sect1 version="5.0" xml:id="sec.parent" xml:base="tests/cases/xinclude2.xml">
+    <sect2 xml:id="sec.first">
+        <para>First section! Found bar!</para>
+    </sect2>
+    <sect2 xml:id="sec.ond">
+        <para>Second section!</para>
+    </sect2>
+</sect1>
+</article>

--- a/tests/cases/xinclude-with-extentity.case.xml
+++ b/tests/cases/xinclude-with-extentity.case.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<article version="5.0"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>Transclusions demo</title>
+  <xi:include href="xinclude3.xml"/>
+</article>

--- a/tests/cases/xinclude-with-extentity.out.xml
+++ b/tests/cases/xinclude-with-extentity.out.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="tests/cases/xinclude-with-extentity.case.xml">
+  <title>Transclusions demo</title>
+  <sect1 version="5.0" xml:id="sec.parent" xml:base="tests/cases/xinclude3.xml">
+    <sect2 xml:id="sec.first">
+        <para>First section! Found bar!</para>
+    </sect2>
+    <sect2 xml:id="sec.ond">
+        <para>Second section!</para>
+    </sect2>
+</sect1>
+</article>

--- a/tests/cases/xinclude2.xml
+++ b/tests/cases/xinclude2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 [
+  <!ENTITY bar "Found bar!">
+]>
+<sect1 version="5.0"
+    xmlns="http://docbook.org/ns/docbook"
+    xml:id="sec.parent">
+    <sect2 xml:id="sec.first">
+        <para>First section! &bar;</para>
+    </sect2>
+    <sect2 xml:id="sec.ond">
+        <para>Second section!</para>
+    </sect2>
+</sect1>

--- a/tests/cases/xinclude3.xml
+++ b/tests/cases/xinclude3.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 [
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+<sect1 version="5.0"
+    xmlns="http://docbook.org/ns/docbook"
+    xml:id="sec.parent">
+    <sect2 xml:id="sec.first">
+        <para>First section! &bar;</para>
+    </sect2>
+    <sect2 xml:id="sec.ond">
+        <para>Second section!</para>
+    </sect2>
+</sect1>


### PR DESCRIPTION
I've added three new testcase, all dealing with entities. The cases `entity.case.xml` and `xinclude-with-entity.case.xml` are ok; they both define their entities in the same file (either in the "main" or in the xincluded file).

However, the testcase `xinclude-with-extentity.case.xml` refers to an external file `entity-decl.ent`. This file contains the entity definitions. For some reason, this isn't possible, although it's correct XML.

Oh, by the way: executing `dbxincluder` with the respective file gives the following error:

```
$ dbxincluder tests/cases/xinclude-with-extentity.case.xml
Error at tests/cases/xinclude-with-extentity.case.xml:6: Could not parse 'tests/cases/xinclude3.xml': Entity 'bar' not defined, line 10, column 35
```

For some reasons, the file `xinclude3.xml` doesn't resolve the (externally definied) entity which results in the above error message.

@Vogtinator: Fabian, could you look into this issue next week? Thanks!
